### PR TITLE
feat: add ref sheet route

### DIFF
--- a/app/refsheet/page.tsx
+++ b/app/refsheet/page.tsx
@@ -1,0 +1,22 @@
+import Image from 'next/image';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Ref Sheet | Kota Husky',
+  description: 'Character reference sheet for Kota Husky',
+};
+
+export default function RefSheet() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-900 p-4">
+      <Image
+        src="/images/refsheet.png"
+        alt="Kota Husky Reference Sheet"
+        width={1920}
+        height={1080}
+        className="max-h-screen w-auto object-contain"
+        priority
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `/refsheet` page that displays the character reference sheet image
- Uses `next/image` with priority loading and responsive sizing
- Includes dedicated metadata (title + description)

**Note:** Drop `refsheet.png` into `public/images/` to complete.

Closes #1

## Test plan
- [ ] Add `public/images/refsheet.png` and visit `/refsheet`
- [ ] Verify image renders centered and responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)