### PR TITLE
Add build verification workflow

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -1,0 +1,13 @@
+name: Build Verification
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  verify:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/build-verify.yml@main
+    with:
+      node-version: '24'


### PR DESCRIPTION
## Summary
- Add build-verify.yml that calls cicd-toolkit's reusable workflow
- Runs parallel build, test, and lint on push to main and PRs

Depends on: KotaHusky/cicd-toolkit#13

## Test plan
- [ ] Merge cicd-toolkit#13 first
- [ ] Verify workflow runs on this PR
- [ ] Build, test, lint all pass in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)