### PR TITLE
feat: add Docker GHCR workflow

### DIFF
--- a/.github/workflows/aks-deploy.yml
+++ b/.github/workflows/aks-deploy.yml
@@ -1,9 +1,11 @@
 name: Build and Deploy to AKS
 
-on:
-  push:
-    branches:
-      - main
+# Disabled — replaced by docker-ghcr.yml
+# on:
+#   push:
+#     branches:
+#       - main
+on: workflow_dispatch
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -1,0 +1,22 @@
+name: Docker Build & Push to GHCR
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/docker-ghcr.yml@main
+    with:
+      push: ${{ github.event_name == 'push' }}
+    permissions:
+      contents: read
+      packages: write


### PR DESCRIPTION
## Summary
- Adds `docker-ghcr.yml` calling workflow that builds Docker images and pushes to `ghcr.io/kotahusky/homepage`
- PR builds are build-only (no push); merges to main push the image
- Disables old `aks-deploy.yml` triggers (switched to `workflow_dispatch` only)

## Test plan
- [ ] Verify this PR triggers a build-only run (no push to GHCR)
- [ ] After merge, confirm image appears at `ghcr.io/kotahusky/homepage`
- [ ] Confirm `aks-deploy.yml` no longer auto-triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)