### PR TITLE
feat: adopt cicd-toolkit commitlint and add AI release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,17 +17,7 @@ jobs:
       node-version: '24'
 
   commitlint:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-      - run: npm ci
-      - run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }}
+    uses: KotaHusky/cicd-toolkit/.github/workflows/commitlint.yml@main
 
   docker:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -53,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # required: semantic-release needs full history to find tags
           persist-credentials: false
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,14 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    uses: KotaHusky/cicd-toolkit/.github/workflows/release.yml@main
+    permissions:
+      contents: write
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,6 +12,6 @@
         "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    ["@semantic-release/github", { "successComment": false, "failTitle": false }]
   ]
 }


### PR DESCRIPTION
## Summary

- Replace inline commitlint job with reusable `cicd-toolkit/commitlint.yml` workflow
- Disable noisy PR comments from `@semantic-release/github` (`successComment: false`, `failTitle: false`)
- Add `release.yml` calling workflow for AI-powered release notes on tag push

> **Note:** The AI release workflow (`release.yml`) triggers on `v*` tags. Tags created by `GITHUB_TOKEN` don't trigger `on: push: tags` events (GitHub security measure). To enable this, semantic-release will need a PAT or GitHub App token instead of `GITHUB_TOKEN`.

## Test plan

- [ ] Verify commitlint still works on PRs via the reusable workflow
- [ ] Verify semantic-release still works on main pushes
- [ ] Verify docker-release still builds version-tagged images on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)