### PR TITLE
ci: skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'LICENSE'
+      - 'docs/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `paths-ignore` to CI triggers for `*.md`, `LICENSE`, and `docs/**`
- Documentation-only PRs will no longer trigger build, test, and lint jobs

## Test plan
- [ ] Verify docs-only PRs skip CI
- [ ] Verify code changes still trigger CI normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)