### PR TITLE
chore(infra): pin cicd-toolkit to v2.1.0

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "aws-cdk-lib": "^2.178.0",
-        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#feat/ecs-express-edge",
+        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.1.0",
         "constructs": "^10.4.2"
       },
       "devDependencies": {

--- a/infra/package.json
+++ b/infra/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",
     "constructs": "^10.4.2",
-    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#feat/ecs-express-edge"
+    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.17.14",


### PR DESCRIPTION
Switches the infra/ edge-stack dependency from `cicd-toolkit#feat/ecs-express-edge` to the released tag `cicd-toolkit#v2.1.0`.

Verified: `npm install` + `cdk synth` resolve and synthesize against the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)