### PR TITLE
fix(docker): exclude infra/ from image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ e2e
 jest.config*
 vitest.config*
 tsconfig*.json
+infra
+cdk.out


### PR DESCRIPTION
The Docker build runs `next build` over the copied repo; since `.dockerignore` drops `tsconfig*.json`, the root tsconfig's `infra` exclude doesn't apply inside the container, so `infra/bin/app.ts` (imports aws-cdk-lib) breaks the build. Excludes `infra/` + `cdk.out` from the Docker context. Caught by the first ECS Express smoke deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)