### PR TITLE
fix(ci): lowercase GHCR source-image ref

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -63,7 +63,7 @@ jobs:
       - id: mirror
         uses: KotaHusky/cicd-toolkit/actions/ecr-mirror@v2
         with:
-          source-image: ghcr.io/${{ github.repository }}@${{ needs.image.outputs.digest }}
+          source-image: ghcr.io/kotahusky/${{ env.SERVICE_NAME }}@${{ needs.image.outputs.digest }}
           ecr-repo: ${{ env.SERVICE_NAME }}
           ecr-tag: ${{ github.sha }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
github.repository preserves case; Docker refs must be lowercase. Use `ghcr.io/kotahusky/$SERVICE_NAME`. Caught by the ECS Express smoke deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)