### PR TITLE
feat(infra): v2.2.0 observability + robust ALB resolution

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -34,6 +34,9 @@ env:
   HEALTH_CHECK_PATH: /api/health
   DOMAIN_NAME: kota.dog
   HOSTED_ZONE_NAME: kota.dog
+  # Observability tier for the edge stack: dev (dashboard only) or prod
+  # (dashboard + alarms + access logs + 90d retention). Flip to prod after cutover.
+  OBSERVABILITY_TIER: dev
 
 jobs:
   # 1. Build the Next.js standalone image and push to GHCR.
@@ -100,22 +103,35 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
-      - name: Resolve ALB + ECS identifiers for the dashboard
+      - name: Resolve ALB + ECS identifiers for the dashboard (best-effort)
         id: ids
         shell: bash
         run: |
-          set -euo pipefail
-          ENDPOINT='${{ needs.service.outputs.endpoint }}'
+          # Best-effort: never fail the deploy if identifiers can't be resolved
+          # (edge still deploys; ALB/ECS dashboard widgets just degrade).
           SERVICE_ARN='${{ needs.service.outputs.service-arn }}'
           # arn:aws:ecs:region:acct:service/<cluster>/<service>
           echo "cluster=$(echo "$SERVICE_ARN" | awk -F'/' '{print $2}')" >> "$GITHUB_OUTPUT"
           echo "service=$(echo "$SERVICE_ARN" | awk -F'/' '{print $3}')" >> "$GITHUB_OUTPUT"
+          # ECS Express uses a shared gateway ALB named ecs-express-gateway-alb-*
           LB_ARN=$(aws elbv2 describe-load-balancers \
-            --query "LoadBalancers[?DNSName=='${ENDPOINT}'].LoadBalancerArn | [0]" --output text)
-          echo "lb=$(echo "$LB_ARN" | sed 's#.*:loadbalancer/##')" >> "$GITHUB_OUTPUT"
-          TG_ARN=$(aws elbv2 describe-target-groups --load-balancer-arn "$LB_ARN" \
-            --query 'TargetGroups[0].TargetGroupArn' --output text)
-          echo "tg=$(echo "$TG_ARN" | sed 's#.*:##')" >> "$GITHUB_OUTPUT"
+            --query "LoadBalancers[?starts_with(LoadBalancerName,'ecs-express-gateway')].LoadBalancerArn | [0]" \
+            --output text 2>/dev/null || true)
+          if [ -n "$LB_ARN" ] && [ "$LB_ARN" != "None" ]; then
+            echo "lb=$(echo "$LB_ARN" | sed 's#.*:loadbalancer/##')" >> "$GITHUB_OUTPUT"
+            TG_ARN=$(aws elbv2 describe-target-groups --load-balancer-arn "$LB_ARN" \
+              --query "TargetGroups[?contains(TargetGroupName,'${SERVICE_NAME}')].TargetGroupArn | [0]" \
+              --output text 2>/dev/null || true)
+            if [ -z "$TG_ARN" ] || [ "$TG_ARN" = "None" ]; then
+              TG_ARN=$(aws elbv2 describe-target-groups --load-balancer-arn "$LB_ARN" \
+                --query 'TargetGroups[0].TargetGroupArn' --output text 2>/dev/null || true)
+            fi
+            if [ -n "$TG_ARN" ] && [ "$TG_ARN" != "None" ]; then
+              echo "tg=$(echo "$TG_ARN" | sed 's#.*:##')" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "::warning::ECS Express gateway ALB not found; dashboard ALB widgets skipped"
+          fi
       - name: Deploy edge stack
         working-directory: infra
         env:
@@ -128,10 +144,13 @@ jobs:
           else
             echo "::notice::Deploying edge WITHOUT custom domain (CloudFront URL only)"
           fi
+          # CloudFront origin is the per-service .on.aws endpoint (the gateway
+          # routes by that hostname). observabilityTier enables dashboard/alarms.
           npx cdk deploy HomepageEdge --require-approval never \
             -c account=${{ env.AWS_ACCOUNT_ID }} \
             -c region=${{ env.AWS_REGION }} \
             -c albDns='${{ needs.service.outputs.endpoint }}' \
+            -c observabilityTier=${{ env.OBSERVABILITY_TIER }} \
             $DOMAIN_FLAGS \
             -c serviceName=${{ env.SERVICE_NAME }} \
             -c loadBalancerFullName='${{ steps.ids.outputs.lb }}' \

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -15,7 +15,7 @@
  *   (dashboard detail).
  */
 import * as cdk from 'aws-cdk-lib';
-import { EcsExpressEdgeStack } from 'cicd-toolkit';
+import { EcsExpressEdgeStack, ObservabilityProps, ObservabilityTier } from 'cicd-toolkit';
 
 const app = new cdk.App();
 const ctx = (k: string): string | undefined => app.node.tryGetContext(k);
@@ -27,12 +27,19 @@ const albDnsName = ctx('albDns');
 if (!account) throw new Error('Pass -c account=<id> (or set CDK_DEFAULT_ACCOUNT).');
 if (!albDnsName) throw new Error('Pass -c albDns=<ecs-express-endpoint>.');
 
+// Opt-in observability: pass -c observabilityTier=dev|prod to enable.
+const tier = ctx('observabilityTier') as ObservabilityTier | undefined;
+const observability: ObservabilityProps | undefined = tier
+  ? { tier, alarmEmail: ctx('alarmEmail'), ecsLogGroupName: ctx('ecsLogGroup') }
+  : undefined;
+
 new EcsExpressEdgeStack(app, 'HomepageEdge', {
   env: { account, region },
   albDnsName,
   domainName: ctx('domainName'),
   hostedZoneName: ctx('hostedZoneName'),
   serviceName: ctx('serviceName') ?? 'homepage',
+  observability,
   loadBalancerFullName: ctx('loadBalancerFullName'),
   targetGroupFullName: ctx('targetGroupFullName'),
   ecsClusterName: ctx('ecsClusterName'),

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "aws-cdk-lib": "^2.178.0",
-        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.1.0",
+        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.2.0",
         "constructs": "^10.4.2"
       },
       "devDependencies": {
@@ -564,7 +564,7 @@
     },
     "node_modules/cicd-toolkit": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#2c775451392212fb19ef5244fabbd7242b63c9e0",
+      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#ae595f5c4f55154fb169334088ebbb85a8b8f822",
       "peerDependencies": {
         "aws-cdk-lib": "^2.178.0",
         "constructs": "^10.4.2"

--- a/infra/package.json
+++ b/infra/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",
-    "constructs": "^10.4.2",
-    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.1.0"
+    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.2.0",
+    "constructs": "^10.4.2"
   },
   "devDependencies": {
     "@types/node": "^20.17.14",


### PR DESCRIPTION
Pins cicd-toolkit v2.2.0, enables opt-in observability (dev tier for now), and makes the gateway-ALB lookup robust + non-fatal. Fixes the edge job that failed because ECS Express's public endpoint is a .on.aws gateway alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)