### PR TITLE
fix(infra): v2.3.0 HTTPS origin + Cloudflare DNS

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -7,14 +7,16 @@ name: Deploy (AWS / ECS Express)
 #   - OIDC deploy role            -> secret AWS_DEPLOY_ROLE_ARN
 #   - ECS task execution role     -> secret ECS_EXECUTION_ROLE_ARN
 #   - ECS infrastructure role     -> secret ECS_INFRASTRUCTURE_ROLE_ARN
-#   - Route53 hosted zone for DOMAIN_NAME (if using a custom domain)
+# DNS is on Cloudflare (no Route53). For a custom domain: import a us-east-1 ACM
+# cert via -c certificateArn=..., then add the Cloudflare records (CNAME ->
+# DistributionDomain) using the Cloudflare MCP server. See infra/README.aws.md.
 # Set AWS_ACCOUNT_ID as a repo variable, then uncomment the `push` trigger.
 
 on:
   workflow_dispatch:
     inputs:
       custom_domain:
-        description: 'Deploy with the custom domain (ACM + Route53). Set false to smoke-test on the CloudFront URL only (no DNS).'
+        description: 'Deploy with the custom domain (ACM cert; Cloudflare DNS). Set false to smoke-test on the CloudFront URL only.'
         type: boolean
         default: true
   # push:
@@ -33,7 +35,6 @@ env:
   CONTAINER_PORT: '3000'
   HEALTH_CHECK_PATH: /api/health
   DOMAIN_NAME: kota.dog
-  HOSTED_ZONE_NAME: kota.dog
   # Observability tier for the edge stack: dev (dashboard only) or prod
   # (dashboard + alarms + access logs + 90d retention). Flip to prod after cutover.
   OBSERVABILITY_TIER: dev
@@ -140,7 +141,7 @@ jobs:
           npm ci
           DOMAIN_FLAGS=""
           if [ "${USE_DOMAIN:-true}" = "true" ]; then
-            DOMAIN_FLAGS="-c domainName=${{ env.DOMAIN_NAME }} -c hostedZoneName=${{ env.HOSTED_ZONE_NAME }}"
+            DOMAIN_FLAGS="-c domainName=${{ env.DOMAIN_NAME }}"
           else
             echo "::notice::Deploying edge WITHOUT custom domain (CloudFront URL only)"
           fi

--- a/infra/README.aws.md
+++ b/infra/README.aws.md
@@ -1,0 +1,32 @@
+# Homepage AWS edge infra (CDK)
+
+> ⚠️ This `infra/` dir currently holds **both** the legacy Azure Bicep
+> (`main.bicep`, `modules/`, `README.md`) and this AWS CDK app
+> (`cdk.json`, `bin/app.ts`). They coexist during the Azure→AWS migration;
+> once AWS is verified and Azure retired, remove the Bicep files (or move CDK
+> to `infra/aws/`).
+
+CDK app that deploys the CloudFront edge (+ optional observability) in front of
+the Homepage ECS Express service, via `EcsExpressEdgeStack` from `cicd-toolkit`.
+
+- **DNS is on Cloudflare** — this stack never uses Route53.
+- CloudFront origin is the ECS Express `.on.aws` endpoint (HTTPS).
+- Deployed by `.github/workflows/deploy-aws.yml` (config lives there).
+
+## Custom domain on Cloudflare (via the Cloudflare MCP server)
+
+1. **ACM cert (us-east-1).** Mint a DNS-validated cert for `kota.dog`. Using the
+   **Cloudflare MCP server**, add the ACM validation `CNAME` to the `kota.dog`
+   zone and leave it (needed for auto-renewal). Pass the issued cert ARN to the
+   deploy: `-c certificateArn=arn:aws:acm:us-east-1:...` (importing a
+   pre-validated cert keeps CI from blocking on validation).
+2. **Point the domain at CloudFront.** After deploy, read the
+   `DistributionDomain` output and, via the Cloudflare MCP server, create
+   `CNAME kota.dog -> <DistributionDomain>` — **DNS-only (grey cloud)**; don't
+   proxy (CloudFront already fronts it). For the apex, enable Cloudflare CNAME
+   flattening.
+
+## Smoke test (no domain)
+
+`workflow_dispatch` with `custom_domain=false` deploys on the
+`dXXXX.cloudfront.net` URL only — no ACM, no DNS.

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -4,13 +4,13 @@
  *
  * The ECS Express service + ALB are created by the deploy workflow
  * (`.github/workflows/deploy-aws.yml`). This CDK app only owns the edge:
- * CloudFront + ACM + Route53 + a CloudWatch dashboard, via the shared
- * `EcsExpressEdgeStack` from cicd-toolkit.
+ * CloudFront + ACM + optional CloudWatch observability, via the shared
+ * `EcsExpressEdgeStack` from cicd-toolkit. DNS is on Cloudflare (no Route53).
  *
  * All config is supplied as CDK context by the workflow (-c key=value), so the
  * account/domain/service live in the consuming workflow, not here:
  *   account, region, albDns (required),
- *   domainName, hostedZoneName, serviceName (custom domain),
+ *   domainName, serviceName (custom domain; DNS on Cloudflare),
  *   loadBalancerFullName, targetGroupFullName, ecsClusterName, ecsServiceName
  *   (dashboard detail).
  */
@@ -37,7 +37,6 @@ new EcsExpressEdgeStack(app, 'HomepageEdge', {
   env: { account, region },
   albDnsName,
   domainName: ctx('domainName'),
-  hostedZoneName: ctx('hostedZoneName'),
   serviceName: ctx('serviceName') ?? 'homepage',
   observability,
   loadBalancerFullName: ctx('loadBalancerFullName'),

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "aws-cdk-lib": "^2.178.0",
-        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.2.0",
+        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.3.0",
         "constructs": "^10.4.2"
       },
       "devDependencies": {
@@ -564,7 +564,7 @@
     },
     "node_modules/cicd-toolkit": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#ae595f5c4f55154fb169334088ebbb85a8b8f822",
+      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#a87987f6a96ea10410aadc5c5643805e6b835c66",
       "peerDependencies": {
         "aws-cdk-lib": "^2.178.0",
         "constructs": "^10.4.2"

--- a/infra/package.json
+++ b/infra/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",
-    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.2.0",
+    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.3.0",
     "constructs": "^10.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes the CloudFront 504 (origin now HTTPS_ONLY for the .on.aws endpoint) and drops Route53 (DNS on Cloudflare). Adds Cloudflare MCP directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)