### PR TITLE
perf(ci): build caching + conditional edge; fix dashboard name collision

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -68,6 +68,22 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+  # 0b. Detect whether the edge (infra/) changed. On push, the slow CloudFront
+  #     edge job is skipped unless infra/ changed; dispatch always runs it.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      infra: ${{ steps.f.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+              - '.github/workflows/deploy-aws.yml'
+
   # 1. Build the Next.js standalone image (shared across envs) and push to GHCR.
   image:
     uses: KotaHusky/cicd-toolkit/.github/workflows/docker-ghcr.yml@main
@@ -117,8 +133,13 @@ jobs:
       infrastructure-role-arn: ${{ secrets.ECS_INFRASTRUCTURE_ROLE_ARN }}
 
   # 4. Deploy the CloudFront edge + observability for this environment.
+  #    Skipped on push when infra/ is unchanged (CloudFront is the slow step);
+  #    always runs on manual dispatch.
   edge:
-    needs: [config, service]
+    needs: [config, service, changes]
+    if: >-
+      always() && needs.service.result == 'success' &&
+      (github.event_name == 'workflow_dispatch' || needs.changes.outputs.infra == 'true')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -155,10 +176,15 @@ jobs:
           else
             echo "::warning::ECS Express gateway ALB not found; dashboard ALB widgets skipped"
           fi
+      - name: Cache infra node_modules (rebuilds the cicd-toolkit git dep)
+        uses: actions/cache@v4
+        with:
+          path: infra/node_modules
+          key: infra-nm-${{ runner.os }}-${{ hashFiles('infra/package-lock.json') }}
       - name: Deploy edge stack (${{ needs.config.outputs.env }})
         working-directory: infra
         run: |
-          npm ci
+          npm ci --prefer-offline
           npx cdk deploy ${{ needs.config.outputs.stack }} --require-approval never \
             -c account=${{ env.AWS_ACCOUNT_ID }} \
             -c region=${{ env.AWS_REGION }} \
@@ -168,6 +194,7 @@ jobs:
             -c certificateArn=${{ needs.config.outputs.cert_arn }} \
             -c observabilityTier=${{ needs.config.outputs.obs_tier }} \
             -c serviceName=${{ needs.config.outputs.service }} \
+            -c dashboardName=${{ needs.config.outputs.stack }} \
             -c loadBalancerFullName='${{ steps.ids.outputs.lb }}' \
             -c targetGroupFullName='${{ steps.ids.outputs.tg }}' \
             -c ecsClusterName='${{ steps.ids.outputs.cluster }}' \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 FROM node:24-alpine AS base
 
 # Install dependencies only when needed
@@ -6,7 +7,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm npm ci
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -16,7 +17,7 @@ COPY . .
 
 ENV NEXT_TELEMETRY_DISABLED=1
 
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache npm run build
 
 # Production image, copy only what's needed
 FROM base AS runner

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -43,6 +43,9 @@ new EcsExpressEdgeStack(app, stackName, {
   domainName: ctx('domainName'),
   certificateArn: ctx('certificateArn'),
   serviceName: ctx('serviceName') ?? 'homepage',
+  // Dashboard names are account-global; key to the stack so dev/prod and any
+  // legacy stacks never collide.
+  dashboardName: ctx('dashboardName') ?? stackName,
   observability,
   loadBalancerFullName: ctx('loadBalancerFullName'),
   targetGroupFullName: ctx('targetGroupFullName'),

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "aws-cdk-lib": "^2.178.0",
-        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.3.0",
+        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.4.0",
         "constructs": "^10.4.2"
       },
       "devDependencies": {
@@ -564,7 +564,7 @@
     },
     "node_modules/cicd-toolkit": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#a87987f6a96ea10410aadc5c5643805e6b835c66",
+      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#24109a5a735fdc25c4bd932296445d95293d5dba",
       "peerDependencies": {
         "aws-cdk-lib": "^2.178.0",
         "constructs": "^10.4.2"

--- a/infra/package.json
+++ b/infra/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",
-    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.3.0",
+    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.4.0",
     "constructs": "^10.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes the prod edge failure (account-global dashboard name collision) by keying the dashboard to the stack. Adds CI perf: conditional edge on push, Docker cache mounts, infra node_modules cache, crane mirror (v2.4.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)