### PR TITLE
fix: visible button outlines + no-cache edge policy (v2.5.1)

### DIFF
--- a/app/components/homepage-button.tsx
+++ b/app/components/homepage-button.tsx
@@ -14,7 +14,7 @@ export function HomepageButton(props: HomepageButtonProps) {
       href={href}
       target="_blank"
       rel="noreferrer"
-      className={`block text-center bg-white/5 hover:bg-blue-500/20 text-white font-bold py-2 px-4 w-full min-w-[100px] max-w-[200px] mb-4 rounded border border-solid border-white/10 hover:border-blue-400/30 backdrop-blur-sm shadow-md transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${className ?? ''}`}
+      className={`block text-center bg-white/5 hover:bg-blue-500/20 text-white font-bold py-2 px-4 w-full min-w-[100px] max-w-[200px] mb-4 rounded border border-solid border-white/30 hover:border-blue-400/50 backdrop-blur-sm shadow-md transition duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent ${className ?? ''}`}
     >
       {buttonText}
     </a>

--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "aws-cdk-lib": "^2.178.0",
-        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.0",
+        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.1",
         "constructs": "^10.4.2"
       },
       "devDependencies": {
@@ -564,7 +564,7 @@
     },
     "node_modules/cicd-toolkit": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#be907368791ce731290135ef5384437a8a1ec530",
+      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#8166b72db03605b9714641acafe32c7f5415889b",
       "peerDependencies": {
         "aws-cdk-lib": "^2.178.0",
         "constructs": "^10.4.2"

--- a/infra/package.json
+++ b/infra/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",
-    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.0",
+    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.1",
     "constructs": "^10.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
- **Outlines:** button border was `border-white/10` (~10% opacity, invisible). Bumped to `border-white/30` (hover `blue-400/50`).
- **Cache:** pin infra `cicd-toolkit` v2.5.0 -> v2.5.1 — edge stack now overrides SSR `Cache-Control` to `no-cache, must-revalidate` so deploys show immediately (no stale page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)