### PR TITLE
fix(infra): toolkit v2.5.2 — repair /_next/image

### DIFF
--- a/infra/package-lock.json
+++ b/infra/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "aws-cdk-lib": "^2.178.0",
-        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.1",
+        "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.2",
         "constructs": "^10.4.2"
       },
       "devDependencies": {
@@ -564,7 +564,7 @@
     },
     "node_modules/cicd-toolkit": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#8166b72db03605b9714641acafe32c7f5415889b",
+      "resolved": "git+ssh://git@github.com/KotaHusky/cicd-toolkit.git#118bbed144fb299dfe58de25796cd815145abd17",
       "peerDependencies": {
         "aws-cdk-lib": "^2.178.0",
         "constructs": "^10.4.2"

--- a/infra/package.json
+++ b/infra/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "^2.178.0",
-    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.1",
+    "cicd-toolkit": "github:KotaHusky/cicd-toolkit#v2.5.2",
     "constructs": "^10.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps edge pin to v2.5.2 so CloudFront forwards the query string to `/_next/image` — fixes broken optimized images (optimizer 400'd because CACHING_OPTIMIZED dropped `url/w/q`).