### PR TITLE
fix(docker): keep tsconfig.base.json in build context for monorepo build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,6 +9,8 @@ e2e
 .prettierrc*
 jest.config*
 vitest.config*
-tsconfig*.json
+# Do NOT ignore tsconfig*.json: apps/web/tsconfig.json extends the root
+# tsconfig.base.json, which must be present in the Docker build context or
+# `next build` fails to resolve the extends chain.
 infra
 cdk.out


### PR DESCRIPTION
## Problem

The post-merge Docker build for the monorepo (#55) failed:

```
./apps/web/tsconfig.json — extends "../../tsconfig.base.json" doesn't resolve correctly
```

`.dockerignore` excludes `tsconfig*.json`, which strips the root **`tsconfig.base.json`** from the build context. Harmless in the old single-app layout (Next regenerated its tsconfig), but `apps/web/tsconfig.json` now *extends* it, so `next build` can't resolve the chain inside the container.

The live site was unaffected — `deploy` is gated on `docker` succeeding, so it skipped and the previous deployment kept running. But deploys are blocked until this lands.

## Fix

Stop ignoring `tsconfig*.json` so `tsconfig.base.json` reaches the build context (with a comment so it isn't re-added). Mirrors the local build, which has all tsconfigs present and passes.

## Note

The `docker` job only runs on push to `main` (not on PRs), so this is validated by the post-merge run. `deploy` stays gated behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
