### PR TITLE
feat(ui): brand-recolored avatar outline + arrows on ProfileCarousel

### DIFF
--- a/packages/ui/src/components/profile-carousel.tsx
+++ b/packages/ui/src/components/profile-carousel.tsx
@@ -72,7 +72,7 @@ export function ProfileCarousel({
     >
       <button
         onClick={() => handleArrowClick(-1)}
-        className="rounded-full text-gray-400 hover:text-white transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+        className="rounded-full text-brand-400/60 hover:text-brand-300 transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
         aria-label="Previous photo"
       >
         <ChevronLeftIcon className="w-6 h-6 md:w-8 md:h-8" />
@@ -86,10 +86,12 @@ export function ProfileCarousel({
           return (
             <div
               key={img.alt}
-              className="absolute top-1/2 left-1/2 w-32 h-32 md:w-64 md:h-64 rounded-full overflow-hidden transition-all duration-700 ease-in-out"
+              className="absolute top-1/2 left-1/2 w-32 h-32 md:w-64 md:h-64 rounded-full overflow-hidden border border-brand-700/70 transition-all duration-700 ease-in-out"
               style={{
+                // Inline opacity (not an `opacity-*` class) so it actually wins —
+                // a Tailwind class here would be overridden by this inline style.
                 transform: `translate(-50%, -50%) translateX(${offset * 85}%) scale(${isCenter ? 1 : 0.5})`,
-                opacity: 1,
+                opacity: 0.9,
                 zIndex: isCenter ? 10 : 0,
               }}
             >
@@ -109,7 +111,7 @@ export function ProfileCarousel({
 
       <button
         onClick={() => handleArrowClick(1)}
-        className="rounded-full text-gray-400 hover:text-white transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+        className="rounded-full text-brand-400/60 hover:text-brand-300 transition-colors p-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-400 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
         aria-label="Next photo"
       >
         <ChevronRightIcon className="w-6 h-6 md:w-8 md:h-8" />


### PR DESCRIPTION
## What

Bring the `ProfileCarousel` avatars in line with the design requirement: a subtle **1px outline** and **slight transparency**, with the prev/next **arrows recolored to the brand palette** so they follow each consuming app (red on afterdark, blue on homepage) instead of fixed gray.

## Changes (`packages/ui/src/components/profile-carousel.tsx`)

- Avatar: add `border border-brand-700/70` (1px outline) and set inline **`opacity: 0.9`**.
  - Deliberately inline, not an `opacity-*` class — the element already carries an inline `style={{ ... }}`, and an inline opacity always wins over a utility class. (This is the trap the consuming app hit: its `opacity-90` class was silently overridden, so the avatars never actually went transparent.)
- Arrows: `text-gray-400 hover:text-white` → `text-brand-400/60 hover:text-brand-300` (recolor-aware).

No API change. Reduced-motion / focus-pause / ARIA behavior unchanged.

## Why

afterdark is about to consume `@kotahusky/ui`, and this is the one component whose published look regressed an explicit design requirement. Putting the polish in the package (recolored via `brand-*`) keeps a single source of truth and gives the homepage the same treatment in blue.

## Release

`feat(ui)` → `release-ui` will publish **`@kotahusky/ui@0.2.0`** to GitHub Packages on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
